### PR TITLE
Fix trying to parse cached responses that don't exist

### DIFF
--- a/src/Service/DeliveryDateService.php
+++ b/src/Service/DeliveryDateService.php
@@ -118,7 +118,7 @@ class DeliveryDateService extends AbstractService implements DeliveryDateService
     {
         $item = $this->retrieveCachedItem($getDeliveryDate->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -166,7 +166,7 @@ class DeliveryDateService extends AbstractService implements DeliveryDateService
     {
         $item = $this->retrieveCachedItem($getDeliveryDate->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -215,7 +215,7 @@ class DeliveryDateService extends AbstractService implements DeliveryDateService
     {
         $item = $this->retrieveCachedItem($getSentDate->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -263,7 +263,7 @@ class DeliveryDateService extends AbstractService implements DeliveryDateService
     {
         $item = $this->retrieveCachedItem($getSentDate->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);

--- a/src/Service/LabellingService.php
+++ b/src/Service/LabellingService.php
@@ -119,7 +119,7 @@ class LabellingService extends AbstractService implements LabellingServiceInterf
     {
         $item = $this->retrieveCachedItem($generateLabel->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -175,7 +175,7 @@ class LabellingService extends AbstractService implements LabellingServiceInterf
         foreach ($generateLabels as $uuid => $generateLabel) {
             $item = $this->retrieveCachedItem($uuid);
             $response = null;
-            if ($item instanceof CacheItemInterface) {
+            if ($item instanceof CacheItemInterface && $item->isHit()) {
                 $response = $item->get();
                 $response = PsrMessage::parseResponse($response);
                 $responses[$uuid] = $response;
@@ -231,7 +231,7 @@ class LabellingService extends AbstractService implements LabellingServiceInterf
     {
         $item = $this->retrieveCachedItem($generateLabel->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -280,7 +280,7 @@ class LabellingService extends AbstractService implements LabellingServiceInterf
         foreach ($generateLabels as $uuid => $generateLabel) {
             $item = $this->retrieveCachedItem($uuid);
             $response = null;
-            if ($item instanceof CacheItemInterface) {
+            if ($item instanceof CacheItemInterface && $item->isHit()) {
                 $response = $item->get();
                 $response = PsrMessage::parseResponse($response);
                 $responses[$uuid] = $response;

--- a/src/Service/LocationService.php
+++ b/src/Service/LocationService.php
@@ -124,7 +124,7 @@ class LocationService extends AbstractService implements LocationServiceInterfac
     {
         $item = $this->retrieveCachedItem($getNearestLocations->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -173,7 +173,7 @@ class LocationService extends AbstractService implements LocationServiceInterfac
     {
         $item = $this->retrieveCachedItem($getNearestLocations->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -222,7 +222,7 @@ class LocationService extends AbstractService implements LocationServiceInterfac
     {
         $item = $this->retrieveCachedItem($getLocations->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -271,7 +271,7 @@ class LocationService extends AbstractService implements LocationServiceInterfac
     {
         $item = $this->retrieveCachedItem($getNearestLocations->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -321,7 +321,7 @@ class LocationService extends AbstractService implements LocationServiceInterfac
     {
         $item = $this->retrieveCachedItem($getLocation->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -370,7 +370,7 @@ class LocationService extends AbstractService implements LocationServiceInterfac
     {
         $item = $this->retrieveCachedItem($getLocation->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);

--- a/src/Service/ShippingService.php
+++ b/src/Service/ShippingService.php
@@ -89,7 +89,7 @@ class ShippingService extends AbstractService implements ShippingServiceInterfac
         $item = $this->retrieveCachedItem($sendShipment->getId());
         $response = null;
 
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);

--- a/src/Service/ShippingStatusService.php
+++ b/src/Service/ShippingStatusService.php
@@ -121,7 +121,7 @@ class ShippingStatusService extends AbstractService implements ShippingStatusSer
     {
         $item = $this->retrieveCachedItem($currentStatus->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -172,7 +172,7 @@ class ShippingStatusService extends AbstractService implements ShippingStatusSer
         foreach ($currentStatuses as $index => $currentStatus) {
             $item = $this->retrieveCachedItem($index);
             $response = null;
-            if ($item instanceof CacheItemInterface) {
+            if ($item instanceof CacheItemInterface && $item->isHit()) {
                 $response = $item->get();
                 $response = PsrMessage::parseResponse($response);
                 $responses[$index] = $response;
@@ -239,7 +239,7 @@ class ShippingStatusService extends AbstractService implements ShippingStatusSer
             $item = null;
         }
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -290,7 +290,7 @@ class ShippingStatusService extends AbstractService implements ShippingStatusSer
         foreach ($completeStatuses as $index => $completeStatus) {
             $item = $this->retrieveCachedItem($index);
             $response = null;
-            if ($item instanceof CacheItemInterface) {
+            if ($item instanceof CacheItemInterface && $item->isHit()) {
                 $response = $item->get();
                 $response = PsrMessage::parseResponse($response);
                 $responses[$index] = $response;
@@ -348,7 +348,7 @@ class ShippingStatusService extends AbstractService implements ShippingStatusSer
     {
         $item = $this->retrieveCachedItem($getSignature->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -399,7 +399,7 @@ class ShippingStatusService extends AbstractService implements ShippingStatusSer
         foreach ($getSignatures as $index => $getsignature) {
             $item = $this->retrieveCachedItem($index);
             $response = null;
-            if ($item instanceof CacheItemInterface) {
+            if ($item instanceof CacheItemInterface && $item->isHit()) {
                 $response = $item->get();
                 $response = PsrMessage::parseResponse($response);
                 $responses[$index] = $response;
@@ -749,7 +749,7 @@ class ShippingStatusService extends AbstractService implements ShippingStatusSer
 
         $item = $this->retrieveCachedItem("{$customer->getCustomerNumber()}-$dateTimeFromString-$dateTimeToString");
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);

--- a/src/Service/TimeframeService.php
+++ b/src/Service/TimeframeService.php
@@ -113,7 +113,7 @@ class TimeframeService extends AbstractService implements TimeframeServiceInterf
     {
         $item = $this->retrieveCachedItem($getTimeframes->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);
@@ -161,7 +161,7 @@ class TimeframeService extends AbstractService implements TimeframeServiceInterf
     {
         $item = $this->retrieveCachedItem($getTimeframes->getId());
         $response = null;
-        if ($item instanceof CacheItemInterface) {
+        if ($item instanceof CacheItemInterface && $item->isHit()) {
             $response = $item->get();
             try {
                 $response = PsrMessage::parseResponse($response);


### PR DESCRIPTION
`PsrMessage::parseResponse()` expects a `string`, but if the cache item wasn't a hit `$item->get()` returns `null` which results in a `TypeError` on PHP 7 and up