### PR TITLE
confirm parameter should be `true` or `false`

### DIFF
--- a/src/Service/LabellingService.php
+++ b/src/Service/LabellingService.php
@@ -342,7 +342,7 @@ class LabellingService extends AbstractService implements LabellingServiceInterf
         return $this->postnl->getRequestFactory()->createRequest(
             'POST',
             $endpoint.'?'.http_build_query([
-                'confirm' => $confirm,
+                'confirm' => ($confirm ? 'true' : 'false'),
             ], '', '&', PHP_QUERY_RFC3986))
             ->withHeader('apikey', $apiKey)
             ->withHeader('Accept', 'application/json')


### PR DESCRIPTION
According to the PostNL Integrations helpdesk, the `confirm` parameter in the Labelling API should be `true` or `false`, not 0 or 1.
`confirm=0` wil actually confirm the label..