### PR TITLE
Fix to retrieve DownPartnerID

### DIFF
--- a/src/Entity/Response/ResponseShipment.php
+++ b/src/Entity/Response/ResponseShipment.php
@@ -43,7 +43,7 @@ use Firstred\PostNL\Service\TimeframeService;
  * @method string|null      getBarcode()
  * @method string|null      getProductCodeDelivery()
  * @method string|null      getDownPartnerBarcode()
- * @method string|null      getDownPartnerId()
+ * @method string|null      getDownPartnerID()
  * @method string|null      getDownPartnerLocation()
  * @method Label[]|null     getLabels()
  * @method Warning[]|null   getWarnings()


### PR DESCRIPTION
Calling `getDownPartnerId()` on a shipment response returns always null. Changes the method name to `getDownPartnerID`, to make this work. This fixes #59