### PR TITLE
Add Shipping default to Warning Entity

### DIFF
--- a/src/Entity/Response/SendShipmentResponse.php
+++ b/src/Entity/Response/SendShipmentResponse.php
@@ -36,7 +36,7 @@ use Firstred\PostNL\Service\ShippingService;
 use Firstred\PostNL\Service\TimeframeService;
 
 /**
- * Class GenerateLabelResponse.
+ * Class SendShipmentResponse.
  *
  * @method MergedLabel[]|null       getMergedLabels()
  * @method ResponseShipment[]|null  getResponseShipments()

--- a/src/Entity/Warning.php
+++ b/src/Entity/Warning.php
@@ -33,6 +33,7 @@ use Firstred\PostNL\Service\ConfirmingService;
 use Firstred\PostNL\Service\DeliveryDateService;
 use Firstred\PostNL\Service\LabellingService;
 use Firstred\PostNL\Service\LocationService;
+use Firstred\PostNL\Service\ShippingService;
 use Firstred\PostNL\Service\TimeframeService;
 use stdClass;
 
@@ -73,6 +74,10 @@ class Warning extends AbstractEntity
         'Timeframe' => [
             'Code'        => TimeframeService::DOMAIN_NAMESPACE,
             'Description' => TimeframeService::DOMAIN_NAMESPACE,
+        ],
+        'Shipping' => [
+            'Code'        => ShippingService::DOMAIN_NAMESPACE,
+            'Description' => ShippingService::DOMAIN_NAMESPACE,
         ],
     ];
     // @codingStandardsIgnoreStart


### PR DESCRIPTION
This prevents `Undefined array key "Shipping" in /vendor/firstred/postnl-api-php/src/Service/AbstractService.php:159` and solves #61