### PR TITLE
fix: prevent error message `foreach() argument must be of type array

### DIFF
--- a/src/Entity/Response/CompleteStatusResponse.php
+++ b/src/Entity/Response/CompleteStatusResponse.php
@@ -122,8 +122,10 @@ class CompleteStatusResponse extends AbstractEntity
 
         $completeStatusResponse = self::create();
         $shipments = [];
-        foreach ($json->CompleteStatusResponse->Shipments as $shipment) {
-            $shipments[] = CompleteStatusResponseShipment::jsonDeserialize((object) ['CompleteStatusResponseShipment' => $shipment]);
+        if (!empty($json->CompleteStatusResponse->Shipments)) {
+            foreach ($json->CompleteStatusResponse->Shipments as $shipment) {
+                $shipments[] = CompleteStatusResponseShipment::jsonDeserialize((object) ['CompleteStatusResponseShipment' => $shipment]);
+            }
         }
         $completeStatusResponse->setShipments($shipments);
 


### PR DESCRIPTION
`isset($json->CompleteStatusResponse->Shipments)` returns false if $json->CompleteStatusResponse->Shipments is set but has the value null (see https://www.php.net/manual/en/function.isset.php).
Therefore $json->CompleteStatusResponse->Shipments will not be forced to an array and ultimately throws an exception at the foreach loop on line 125.

This fixes #63 