### PR TITLE
fix getUpdatedShipments()

### DIFF
--- a/src/PostNL.php
+++ b/src/PostNL.php
@@ -1946,7 +1946,7 @@ class PostNL implements LoggerAwareInterface
      */
     public function getUpdatedShipments($dateTimeFrom = null, $dateTimeTo = null)
     {
-        return $this->shippingStatusService->getUpdatedShipments($this->getCustomer(), $dateTimeFrom, $dateTimeTo);
+        return $this->getShippingStatusService()->getUpdatedShipments($this->getCustomer(), $dateTimeFrom, $dateTimeTo);
     }
 
     /**


### PR DESCRIPTION
`$postNL->getUpdatedShipments(...)` threw an `Call to a member function getUpdatedShipments() on null` error message.
This fixes #66 