### PR TITLE
fix: Confirming Webservice returns code and description in lower case

### DIFF
--- a/src/Entity/Warning.php
+++ b/src/Entity/Warning.php
@@ -114,9 +114,11 @@ class Warning extends AbstractEntity
         // Confirming Webservice has the code and description properties in lower case
         if (isset($json->Warning->code)) {
             $json->Warning->Code = $json->Warning->code;
+            unset($json->Warning->code);
         }
         if (isset($json->Warning->description)) {
             $json->Warning->Description = $json->Warning->description;
+            unset($json->Warning->description);
         }
 
         if (isset($json->Warning->Message)) {

--- a/src/Entity/Warning.php
+++ b/src/Entity/Warning.php
@@ -111,6 +111,14 @@ class Warning extends AbstractEntity
      */
     public static function jsonDeserialize(stdClass $json)
     {
+        // Confirming Webservice returns code and description in lower case
+        if (isset($json->Warning->code)) {
+            $json->Warning->Code = $json->Warning->code;
+        }
+        if (isset($json->Warning->description)) {
+            $json->Warning->Description = $json->Warning->description;
+        }
+
         if (isset($json->Warning->Message)) {
             $json->Warning->Description = $json->Warning->Message;
             unset($json->Warning->Message);

--- a/src/Entity/Warning.php
+++ b/src/Entity/Warning.php
@@ -111,7 +111,7 @@ class Warning extends AbstractEntity
      */
     public static function jsonDeserialize(stdClass $json)
     {
-        // Confirming Webservice returns code and description in lower case
+        // Confirming Webservice has the code and description properties in lower case
         if (isset($json->Warning->code)) {
             $json->Warning->Code = $json->Warning->code;
         }


### PR DESCRIPTION
The Confirming Webservice returns warnings where the Code and Descrription property names are lowercase, resulting in empty codes and descriptions in the Warning object.

This fixes #70 
