### PR TITLE
fix: set Address property if it does not exists

### DIFF
--- a/src/Service/ShippingStatusService.php
+++ b/src/Service/ShippingStatusService.php
@@ -631,6 +631,11 @@ class ShippingStatusService extends AbstractService implements ShippingStatusSer
                     $shipment->Addresses = $shipment->Address;
                     unset($shipment->Address);
                 }
+
+                if (!isset($shipment->Addresses)) {
+                    $shipment->Addresses = [];
+                }
+
                 if (!is_array($shipment->Addresses)) {
                     $shipment->Addresses = [$shipment->Addresses];
                 }


### PR DESCRIPTION
When retrieving the complete shipping status of a Smart Return label, there's no address in the response.
This fix solves #72 