### PR TITLE
Invoke error description in thrown error message.

### DIFF
--- a/src/Exception/CifException.php
+++ b/src/Exception/CifException.php
@@ -60,6 +60,9 @@ class CifException extends ApiException
             $this->messages = $message;
 
             $message = $this->messages[0]['message'];
+            if (!empty($this->messages[0]['description'])) {
+                $message .= ' (' . $this->messages[0]['description'] . ')';
+            }
             $code = $this->messages[0]['code'];
         }
 


### PR DESCRIPTION
When a CIF error is thrown, only the bare error message is thrown.
Example: `Validation failed for shipment: 3XXXXX002981228`.

With this PR, the description is added, so it's a bit easier to find out why the validation failed:
Example: `Validation failed for shipment: 3XXXXX002981228 (Receiver street is required)`.