### PR TITLE
fix: make HttpClientException::response nullable

### DIFF
--- a/src/Exception/HttpClientException.php
+++ b/src/Exception/HttpClientException.php
@@ -41,21 +41,21 @@ use Psr\Http\Message\ResponseInterface;
  */
 class HttpClientException extends PostNLException
 {
-    private ResponseInterface $response;
+    private ?ResponseInterface $response;
 
-    public function __construct(string $message = '', int $code = 0, ?Exception $previous = null, ResponseInterface $response = null)
+    public function __construct(string $message = '', int $code = 0, ?Exception $previous = null, ?ResponseInterface $response = null)
     {
         parent::__construct(message: $message, code: $code, previous: $previous);
 
         $this->response = $response;
     }
 
-    public function setResponse(ResponseInterface $response)
+    public function setResponse(?ResponseInterface $response)
     {
         $this->response = $response;
     }
 
-    public function getResponse(): ResponseInterface
+    public function getResponse(): ?ResponseInterface
     {
         return $this->response;
     }


### PR DESCRIPTION
This makes the property `HttpClientException->response` nullable, and avoids a PHP error, because the response is not always known or given. By making `response` nullable we can catch the _real_ exception.
 
Here is an example trace:
```
Cannot assign null to property Firstred\\PostNL\\Exception\\HttpClientException::$response of type Psr\\Http\\Message\\ResponseInterface

#0 /var/www/html/vendor/firstred/postnl-api-php/src/HttpClient/SymfonyHttpClient.php(193): Firstred\\PostNL\\Exception\\HttpClientException->__construct('Response factor...', 0, Object(Firstred\\PostNL\\Exception\\NotSupportedException))
#1 /var/www/html/vendor/firstred/postnl-api-php/src/Service/LabellingService.php(120): Firstred\\PostNL\\HttpClient\\SymfonyHttpClient->doRequest(Object(GuzzleHttp\\Psr7\\Request))
#2 /var/www/html/vendor/firstred/postnl-api-php/src/PostNL.php(1455): Firstred\\PostNL\\Service\\LabellingService->generateLabel(Object(Firstred\\PostNL\\Entity\\Request\\GenerateLabel), false)
```