### PR TITLE
fix(#82): handle errors responses with a single `Error`

### DIFF
--- a/src/Service/ResponseProcessor/Rest/AbstractRestResponseProcessor.php
+++ b/src/Service/ResponseProcessor/Rest/AbstractRestResponseProcessor.php
@@ -109,7 +109,7 @@ abstract class AbstractRestResponseProcessor extends AbstractResponseProcessor
             }
             throw new CifException(message: $exceptionData);
         } elseif (!empty($body->Error)) {
-            throw new CifException(message: $body->Error->ErrorDescription, code: $body->Error->ErrorCode);
+            throw new CifException(message: (string) $body->Error->ErrorDescription, code: (int) $body->Error->ErrorCode);
         } elseif (!empty($body->Array->Item->ErrorMsg)) {
             // {"Array":{"Item":{"ErrorMsg":"Unknown option GetDeliveryDate.Options='DayTime' specified","ErrorNumber":26}}}
             $exceptionData = [

--- a/src/Service/ResponseProcessor/Rest/AbstractRestResponseProcessor.php
+++ b/src/Service/ResponseProcessor/Rest/AbstractRestResponseProcessor.php
@@ -109,14 +109,7 @@ abstract class AbstractRestResponseProcessor extends AbstractResponseProcessor
             }
             throw new CifException(message: $exceptionData);
         } elseif (!empty($body->Error)) {
-            $error = $body->Error;
-            $exceptionData = [];
-            $exceptionData[] = [
-                'description' => isset($error->ErrorDescription) ? (string) $error->ErrorDescription : '',
-                'message'     => isset($error->ErrorDescription) ? (string) $error->ErrorDescription : '',
-                'code'        => isset($error->ErrorCode) ? (int) $error->ErrorCode : 0,
-            ];
-            throw new CifException(message: $exceptionData);
+            throw new CifException(message: $body->Error->ErrorDescription, code: $body->Error->ErrorCode);
         } elseif (!empty($body->Array->Item->ErrorMsg)) {
             // {"Array":{"Item":{"ErrorMsg":"Unknown option GetDeliveryDate.Options='DayTime' specified","ErrorNumber":26}}}
             $exceptionData = [

--- a/src/Service/ResponseProcessor/Rest/AbstractRestResponseProcessor.php
+++ b/src/Service/ResponseProcessor/Rest/AbstractRestResponseProcessor.php
@@ -108,6 +108,15 @@ abstract class AbstractRestResponseProcessor extends AbstractResponseProcessor
                 }
             }
             throw new CifException(message: $exceptionData);
+        } elseif (!empty($body->Error)) {
+            $error = $body->Error;
+            $exceptionData = [];
+            $exceptionData[] = [
+                'description' => isset($error->ErrorDescription) ? (string) $error->ErrorDescription : '',
+                'message'     => isset($error->ErrorDescription) ? (string) $error->ErrorDescription : '',
+                'code'        => isset($error->ErrorCode) ? (int) $error->ErrorCode : 0,
+            ];
+            throw new CifException(message: $exceptionData);
         } elseif (!empty($body->Array->Item->ErrorMsg)) {
             // {"Array":{"Item":{"ErrorMsg":"Unknown option GetDeliveryDate.Options='DayTime' specified","ErrorNumber":26}}}
             $exceptionData = [

--- a/tests/Resources/responses/rest/location/nearestlocationsbypostcode-error400.http
+++ b/tests/Resources/responses/rest/location/nearestlocationsbypostcode-error400.http
@@ -1,0 +1,19 @@
+HTTP/1.1 400 OK
+Cache-Control: private, max-age=0
+Content-Type: application/json;charset=UTF-8
+Date: Wed, 31 Mar 2021 12:42:12 GMT
+Strict-Transport-Security: max-age=31536000
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Robots-Tag: noindex
+X-XSS-Protection: 1; mode=block
+Connection: keep-alive
+
+{
+  "Date": "2019-08-24T14:15:22Z",
+  "Error": {
+    "ErrorCode": "3000",
+    "ErrorDescription": "Request format is invalid"
+  },
+  "RequestId": "09fd61fe-0099-4349-b71d-dce5c2472be9"
+}


### PR DESCRIPTION
Fixes #82 

This PR improves handling HTTP 400 errors with a single `Error`.

Documentation PostNL API: https://docs.api.postnl.nl/#tag/Locations/paths/~1shipment~1v2_1~1locations~1nearest/get:
```json
// Response 400
{
  "Date": "2019-08-24T14:15:22Z",
  "Error": {
    "ErrorCode": "3000",
    "ErrorDescription": "Request format is invalid"
  },
  "RequestId": "09fd61fe-0099-4349-b71d-dce5c2472be9"
}
```