### PR TITLE
fix(#87): allow getMessagesDescriptionsAndCodes for single Error

### DIFF
--- a/src/Exception/CifException.php
+++ b/src/Exception/CifException.php
@@ -64,6 +64,14 @@ class CifException extends ApiException
                 $message .= ' (' . $this->messages[0]['description'] . ')';
             }
             $code = $this->messages[0]['code'];
+        } else {
+            $this->messages = [
+                [
+                    'message'     => $message,
+                    'description' => $message,
+                    'code'        => $code,
+                ],
+            ];
         }
 
         parent::__construct(message: $message, code: $code, previous: $previous);

--- a/src/Service/ResponseProcessor/Rest/AbstractRestResponseProcessor.php
+++ b/src/Service/ResponseProcessor/Rest/AbstractRestResponseProcessor.php
@@ -109,7 +109,7 @@ abstract class AbstractRestResponseProcessor extends AbstractResponseProcessor
             }
             throw new CifException(message: $exceptionData);
         } elseif (!empty($body->Error)) {
-            throw new CifException(message: (string) $body->Error->ErrorDescription, code: (int) $body->Error->ErrorCode);
+            throw new CifException(message: (string) ($body->Error->ErrorMessage ?? ''), code: (int) ($body->Error->ErrorCode ?? 0));
         } elseif (!empty($body->Array->Item->ErrorMsg)) {
             // {"Array":{"Item":{"ErrorMsg":"Unknown option GetDeliveryDate.Options='DayTime' specified","ErrorNumber":26}}}
             $exceptionData = [

--- a/tests/Exception/CifExceptionTest.php
+++ b/tests/Exception/CifExceptionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firstred\PostNL\Tests\Exception;
+
+use Firstred\PostNL\Exception\CifException;
+use Monolog\Test\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+#[TestDox(text: 'The CifException object')]
+class CifExceptionTest extends TestCase
+{
+    #[TestDox(text: 'Test creating a CifException with a single error')]
+    public function testSingleError(): void
+    {
+        $exception = new CifException(message: 'A test exception', code: 400);
+
+        $this->assertEquals(expected: 'A test exception', actual: $exception->getMessage());
+        $this->assertEquals(expected: 400, actual: $exception->getCode());
+        $this->assertEquals(expected: [
+            [
+                'message'     => 'A test exception',
+                'description' => 'A test exception',
+                'code'        => 400,
+            ],
+        ], actual: $exception->getMessagesDescriptionsAndCodes());
+    }
+
+    #[TestDox(text: 'Test creating a CifException with multiple errors')]
+    public function testMultipleError(): void
+    {
+        $exceptionData = [
+            [
+                'message'     => 'First exception',
+                'description' => 'First description',
+                'code'        => 400,
+            ],
+            [
+                'message'     => 'Second exception',
+                'description' => 'First description',
+                'code'        => 401,
+            ],
+        ];
+        $exception = new CifException(message: $exceptionData, code: 0);
+
+        $this->assertEquals(expected: 'First exception (First description)', actual: $exception->getMessage());
+        $this->assertEquals(expected: 400, actual: $exception->getCode());
+        $this->assertEquals(expected: $exceptionData, actual: $exception->getMessagesDescriptionsAndCodes());
+    }
+}

--- a/tests/Resources/responses/rest/location/nearestlocationsbypostcode-error400.http
+++ b/tests/Resources/responses/rest/location/nearestlocationsbypostcode-error400.http
@@ -13,7 +13,7 @@ Connection: keep-alive
   "Date": "2019-08-24T14:15:22Z",
   "Error": {
     "ErrorCode": "3000",
-    "ErrorDescription": "Request format is invalid"
+    "ErrorMessage": "Request format is invalid"
   },
   "RequestId": "09fd61fe-0099-4349-b71d-dce5c2472be9"
 }


### PR DESCRIPTION
Fixes https://github.com/firstred/postnl-api-php/issues/87.

This PR fixes two issues:

1. Calling `CifException::getMessagesDescriptionsAndCodes` with a single Error:
```
Typed property Firstred\PostNL\Exception\CifException::$messages must not be accessed before initialization
```

2. Fix incorrect PostNL error response for single Error (and allow future changes...)

<table>
<tr>
 <td>Received </td>
<td>According to PostNL API 😩 </td>
</tr>
<tr>

 <td><img width="475" alt="image" src="https://github.com/firstred/postnl-api-php/assets/2487949/b06af24d-94bb-44f5-bfa1-e7472bdd031f">
 </td>
<td><img width="536" alt="image" src="https://github.com/firstred/postnl-api-php/assets/2487949/631a6dca-4b6b-4c51-be62-28e782ce9109">
</td>
</tr>
</table>



