### PR TITLE
Add MT (Malta) to list of 3S countries

### DIFF
--- a/src/PostNL.php
+++ b/src/PostNL.php
@@ -177,6 +177,7 @@ class PostNL implements LoggerAwareInterface
         'LT',
         'LU',
         'LV',
+        'MT',
         'NL',
         'PL',
         'PT',


### PR DESCRIPTION
An update to the list of 3S countries.

https://docs.api.postnl.nl/#tag/Product-codes/Destination-EU/Parcels-EU mentions Malta as a destination with a 3S code. This PR adds Malta to the list 