### PR TITLE
Update guzzlehttp/promises package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^8.1",
         "composer/ca-bundle": "^1.0",
-        "guzzlehttp/promises": "^1.0",
+        "guzzlehttp/promises": "^1.0 || ^2.0",
         "guzzlehttp/psr7": "^1.7 || ^2.0",
         "paragonie/hidden-string": "^2.0",
         "php-http/discovery": "^1.9.1",


### PR DESCRIPTION
* Update the guzzlehttp/promises requirements to also allow ^2.0 versions. 
* Other packages may only require ^2.0, so this PR makes the package more compatible with other packages