### PR TITLE
chore: always validate reponse from PostNL

### DIFF
--- a/src/Service/ResponseProcessor/Rest/BarcodeServiceRestResponseProcessor.php
+++ b/src/Service/ResponseProcessor/Rest/BarcodeServiceRestResponseProcessor.php
@@ -63,18 +63,12 @@ class BarcodeServiceRestResponseProcessor extends AbstractRestResponseProcessor 
     public function processGenerateBarcodeResponse(ResponseInterface $response): string
     {
         $this->validateResponse(response: $response);
-        $responseContent = $this->getResponseText(response: $response);
+        $body = json_decode(json: static::getResponseText(response: $response));
 
-        try {
-            $json = json_decode(json: $responseContent, flags: JSON_THROW_ON_ERROR);
-        } catch (JsonException $e) {
-            throw new ResponseException(message: 'Invalid API Response', previous: $e, response: $response);
-        }
-
-        if (!isset($json->Barcode)) {
+        if (!isset($body->Barcode)) {
             throw new ResponseException(message: 'Invalid API Response', response: $response);
         }
 
-        return $json->Barcode;
+        return $body->Barcode;
     }
 }

--- a/src/Service/ResponseProcessor/Rest/DeliveryDateServiceRestResponseProcessor.php
+++ b/src/Service/ResponseProcessor/Rest/DeliveryDateServiceRestResponseProcessor.php
@@ -65,6 +65,7 @@ class DeliveryDateServiceRestResponseProcessor extends AbstractRestResponseProce
      */
     public function processGetDeliveryDateResponse(ResponseInterface $response): GetDeliveryDateResponse
     {
+        $this->validateResponse(response: $response);
         $body = json_decode(json: static::getResponseText(response: $response));
         if (isset($body->DeliveryDate)) {
             return GetDeliveryDateResponse::jsonDeserialize(json: (object) ['GetDeliveryDateResponse' => $body]);
@@ -91,6 +92,7 @@ class DeliveryDateServiceRestResponseProcessor extends AbstractRestResponseProce
      */
     public function processGetSentDateResponse(ResponseInterface $response): GetSentDateResponse
     {
+        $this->validateResponse(response: $response);
         $body = json_decode(json: static::getResponseText(response: $response));
         if (isset($body->SentDate)) {
             return GetSentDateResponse::jsonDeserialize(json: (object) ['GetSentDateResponse' => $body]);

--- a/src/Service/ResponseProcessor/Rest/LabellingServiceRestResponseProcessor.php
+++ b/src/Service/ResponseProcessor/Rest/LabellingServiceRestResponseProcessor.php
@@ -65,8 +65,8 @@ class LabellingServiceRestResponseProcessor extends AbstractRestResponseProcesso
     public function processGenerateLabelResponse(ResponseInterface $response): GenerateLabelResponse
     {
         $this->validateResponse(response: $response);
-        $responseContent = static::getResponseText(response: $response);
-        $body = json_decode(json: $responseContent);
+        $body = json_decode(json: static::getResponseText(response: $response));
+
         if (isset($body->ResponseShipments)) {
             return GenerateLabelResponse::jsonDeserialize(json: (object) ['GenerateLabelResponse' => $body]);
         }

--- a/src/Service/ResponseProcessor/Rest/ShippingServiceRestResponseProcessor.php
+++ b/src/Service/ResponseProcessor/Rest/ShippingServiceRestResponseProcessor.php
@@ -62,6 +62,7 @@ class ShippingServiceRestResponseProcessor extends AbstractRestResponseProcessor
      */
     public function processSendShipmentResponse(ResponseInterface $response): ?SendShipmentResponse
     {
+        $this->validateResponse(response: $response);
         $body = json_decode(json: static::getResponseText(response: $response));
         if (isset($body->ResponseShipments)) {
             return SendShipmentResponse::JsonDeserialize(json: (object) ['SendShipmentResponse' => $body]);

--- a/src/Service/ResponseProcessor/Rest/ShippingStatusServiceRestResponseProcessor.php
+++ b/src/Service/ResponseProcessor/Rest/ShippingStatusServiceRestResponseProcessor.php
@@ -71,6 +71,7 @@ class ShippingStatusServiceRestResponseProcessor extends AbstractRestResponsePro
      */
     public function processCurrentStatusResponse(ResponseInterface $response): CurrentStatusResponse
     {
+        $this->validateResponse(response: $response);
         $body = json_decode(json: static::getResponseText(response: $response));
 
         /* @var CurrentStatusResponse $object */
@@ -189,6 +190,7 @@ class ShippingStatusServiceRestResponseProcessor extends AbstractRestResponsePro
      */
     public function processGetSignatureResponse(ResponseInterface $response): GetSignatureResponseSignature
     {
+        $this->validateResponse(response: $response);
         $body = json_decode(json: static::getResponseText(response: $response));
 
         /* @var GetSignatureResponseSignature $object */
@@ -212,6 +214,7 @@ class ShippingStatusServiceRestResponseProcessor extends AbstractRestResponsePro
      */
     public function processGetUpdatedShipmentsResponse(ResponseInterface $response): array
     {
+        $this->validateResponse(response: $response);
         $body = json_decode(json: static::getResponseText(response: $response));
         if (!is_array(value: $body)) {
             return [];


### PR DESCRIPTION
I noticed we didn't always received a `CifException`. This was because the `$this->validateResponse($response);` wasn't called for some endpoints. 
