### PR TITLE
Replace DummyLogger with the built-in psr/log NullLogger

### DIFF
--- a/src/PostNL.php
+++ b/src/PostNL.php
@@ -31,6 +31,7 @@ namespace Firstred\PostNL;
 
 use DateTimeInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\NullLogger;
 use Throwable;
 use Firstred\PostNL\Entity\Barcode;
 use Firstred\PostNL\Entity\Customer;
@@ -109,7 +110,6 @@ use Firstred\PostNL\Service\ShippingStatusService;
 use Firstred\PostNL\Service\ShippingStatusServiceInterface;
 use Firstred\PostNL\Service\TimeframeService;
 use Firstred\PostNL\Service\TimeframeServiceInterface;
-use Firstred\PostNL\Util\DummyLogger;
 use Firstred\PostNL\Util\RFPdi;
 use Firstred\PostNL\Util\Util;
 use GuzzleHttp\ClientInterface as GuzzleClientInterface;
@@ -538,7 +538,7 @@ class PostNL implements LoggerAwareInterface
      */
     public function resetLogger(): static
     {
-        $this->logger = new DummyLogger();
+        $this->logger = new NullLogger();
 
         return $this;
     }

--- a/src/Util/DummyLogger.php
+++ b/src/Util/DummyLogger.php
@@ -37,6 +37,7 @@ use Stringable;
  * Class DummyLogger.
  *
  * @internal
+ * @deprecated since 2.0.9. Use the NullLogger from psr/log instead.
  */
 class DummyLogger implements LoggerInterface
 {

--- a/tests/Misc/PostNLRestTest.php
+++ b/tests/Misc/PostNLRestTest.php
@@ -43,13 +43,13 @@ use Firstred\PostNL\Entity\Timeframe;
 use Firstred\PostNL\Exception\InvalidArgumentException;
 use Firstred\PostNL\HttpClient\MockHttpClient;
 use Firstred\PostNL\PostNL;
-use Firstred\PostNL\Util\DummyLogger;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Error;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 #[TestDox(text: 'The PostNL object')]
 class PostNLRestTest extends TestCase
@@ -106,7 +106,7 @@ class PostNLRestTest extends TestCase
     {
         $this->postnl->resetLogger();
 
-        $this->assertInstanceOf(expected: DummyLogger::class, actual: $this->postnl->getLogger());
+        $this->assertInstanceOf(expected: NullLogger::class, actual: $this->postnl->getLogger());
     }
 
     /** @throws */


### PR DESCRIPTION
Replacing the DummyLogger with the built-in psr/log NullLogger ensures compatibillity between all version of the logger interface.

Fixes https://github.com/firstred/postnl-api-php/issues/93 and https://github.com/firstred/postnl-api-php/pull/95