### PR TITLE
Fix: DeliveryDate missing from request

### DIFF
--- a/src/Service/RequestBuilder/Rest/DeliveryDateServiceRestRequestBuilder.php
+++ b/src/Service/RequestBuilder/Rest/DeliveryDateServiceRestRequestBuilder.php
@@ -165,7 +165,7 @@ class DeliveryDateServiceRestRequestBuilder extends AbstractRestRequestBuilder i
 
         $sentDate = $getSentDate->getGetSentDate();
         $query = [
-            'ShippingDate' => $sentDate->getDeliveryDate(),
+            'DeliveryDate' => $sentDate->getDeliveryDate()->format('d-m-Y'),
         ];
         $query['CountryCode'] = $sentDate->getCountryCode();
         if ($duration = $sentDate->getShippingDuration()) {


### PR DESCRIPTION
PR for issue #99 

According to [PostNL's Documentation](https://developer.postnl.nl/docs/#/http/api-endpoints/checkout-delivery-options/deliverydate/calculate-shipping-date), `ShippingDate` isn't a valid parameter for the request. Instead, the documentation says to use `DeliveryDate`.

The `DeliveryDate` parameter only accepts a value following the DD-MM-YYYY format, which is the following pattern:
```regex
^[0-3]\d-[0-1]\d-[1-2]\d{3}$
```
To follow this pattern, and because you can't pass a DateTimeInterface type in the request, I formatted the return value (from the `getDeliveryDate` method) to follow the DD-MM-YYYY pattern. 