### PR TITLE
deps: allow psr/http-message ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "psr/clock": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-factory-implementation": "*",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/http-message-implementation": "*",
         "psr/log": "^1.0.2 || ^2.0 || ^3.0",
         "setasign/fpdf": "^1.8",


### PR DESCRIPTION
This PR allows [`psr/message:^2.0`](https://github.com/php-fig/http-message/releases/tag/2.0).

Other package(s) (https://github.com/aws/aws-sdk-php/pull/3061/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R28) now only supports `psr/message:^2.0`, so this package now blocks other updates. 🙂 